### PR TITLE
Add Java 17 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: java
 
 jdk:
-  - openjdk7
+  # openjdk7 only on ubuntu precise, see https://docs.travis-ci.com/user/reference/precise/#jvm-clojure-groovy-java-scala-vm-images
+  #- openjdk7
   - openjdk8
   - openjdk11
   - openjdk17

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,3 @@ cache:
 
 os:
   - linux
-  - windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,14 @@ language: java
 
 jdk:
   - openjdk7
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
+  - openjdk17
+
+cache:
+  directories:
+    - $HOME/.m2
 
 os:
   - linux
+  - windows

--- a/README.md
+++ b/README.md
@@ -365,6 +365,11 @@ For more details on how to further configure this plugin please see the
 
 ## Changelog
 
+#### Unreleased
+- IMPROVEMENT Added support for Java 17 [Issue 56](https://github.com/webdriverextensions/webdriverextensions-maven-plugin/issues/56)
+- BUGFIX failed to move non-empty directories of downloaded drivers on Windows [Issue 56](https://github.com/webdriverextensions/webdriverextensions-maven-plugin/issues/56)
+- BUGFIX download directory was not always created [Issue 56](https://github.com/webdriverextensions/webdriverextensions-maven-plugin/issues/56)
+
 #### 3.2.0 (2019 June 2)
 - IMPROVEMENT Capability for custom file name with binaries [PR 42](https://github.com/webdriverextensions/webdriverextensions-maven-plugin/issues/42)
 - IMPROVEMENT Maven offline mode should be honored [PR 39](https://github.com/webdriverextensions/webdriverextensions-maven-plugin/issues/39)

--- a/pom.xml
+++ b/pom.xml
@@ -83,53 +83,43 @@
         </repository>
     </distributionManagement>
 
-    <prerequisites>
-        <maven>3.0.4</maven>
-    </prerequisites>
-
     <properties>
         <!-- File Encoding -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Dependency Versions -->
-        <maven-artifact.version>3.2.1</maven-artifact.version>
-        <maven-compat.version>3.2.1</maven-compat.version>
-        <maven-core.version>3.2.1</maven-core.version>
-        <maven-model.version>3.2.1</maven-model.version>
-        <maven-plugin-api.version>3.2.1</maven-plugin-api.version>
+        <maven-core.version>3.3.9</maven-core.version><!-- 1st official maven release that requires Java 1.7 -->
         <maven-plugin-annotations.version>3.3</maven-plugin-annotations.version>
-        <maven-plugin-testing-harness.version>3.1.0</maven-plugin-testing-harness.version>
+        <maven-plugin-testing-harness.version>3.3.0</maven-plugin-testing-harness.version>
 
-        <commons-codec.version>1.10</commons-codec.version>
-        <commons-collections.version>20040616</commons-collections.version>
+        <commons-codec.version>1.15</commons-codec.version>
+        <commons-collections.version>4.2</commons-collections.version>
         <commons-exec.version>1.3</commons-exec.version>
-        <commons-io.version>2.7</commons-io.version>
-        <commons-lang3.version>3.4</commons-lang3.version>
-        <gson.version>2.3.1</gson.version>
+        <commons-io.version>2.6</commons-io.version><!-- latest for java 1.7 -->
+        <commons-lang3.version>3.8.1</commons-lang3.version><!-- latest for java 1.7 -->
+        <gson.version>2.8.8</gson.version>
         <httpclient.version>4.5.13</httpclient.version>
-        <junit.version>4.12</junit.version>
-        <lambdaj.version>2.3.3</lambdaj.version>
-        <selenium.version>2.53.0</selenium.version>
+        <junit.version>4.13.2</junit.version>
+        <selenium.version>2.53.1</selenium.version><!-- latest for java 1.7 -->
 
         <!-- Plugin Versions -->
         <github-site-maven-plugin.version>0.12</github-site-maven-plugin.version>
-        <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
-        <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
-        <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
-        <maven-plugin-plugin.version>3.4</maven-plugin-plugin.version>
-        <maven-project-info-reports-plugin.version>2.8.1</maven-project-info-reports-plugin.version>
-        <maven-release-plugin.version>2.5</maven-release-plugin.version>
-        <maven-source-plugin.version>2.4</maven-source-plugin.version>
-        <nexus-staging-maven-plugin.version>1.6.6</nexus-staging-maven-plugin.version>
-        <webdriverextensions-maven-plugin.version>2.1.0</webdriverextensions-maven-plugin.version>
+        <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+        <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
+        <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
+        <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
+        <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
+        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>${maven-plugin-api.version}</version>
+            <version>${maven-core.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
@@ -157,12 +147,13 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
-            <version>${maven-compat.version}</version>
+            <version>${maven-core.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>${maven-model.version}</version>
+            <version>${maven-core.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -180,13 +171,8 @@
             <version>${gson.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.lambdaj</groupId>
-            <artifactId>lambdaj</artifactId>
-            <version>${lambdaj.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
             <version>${commons-collections.version}</version>
         </dependency>
         <dependency>
@@ -206,13 +192,19 @@
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-java</artifactId>
+            <artifactId>selenium-api</artifactId>
             <version>${selenium.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
+            <version>1.20</version><!-- latest for java 1.7 -->
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>
@@ -231,10 +223,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <compilerArgs>
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
 
@@ -242,6 +239,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>${maven-deploy-plugin.version}</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,13 @@
             <version>${httpclient.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-api</artifactId>
             <version>${selenium.version}</version>

--- a/src/main/java/com/github/webdriverextensions/DriverComparator.java
+++ b/src/main/java/com/github/webdriverextensions/DriverComparator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 WebDriver Extensions.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.webdriverextensions;
+
+import java.util.Comparator;
+
+class DriverComparator {
+
+    private DriverComparator() {
+    }
+
+    static class ById implements Comparator<Driver> {
+
+        @Override
+        public int compare(Driver o1, Driver o2) {
+            if (o1 == null || o1.getId() == null) {
+                return o2 == null || o2.getId() == null ? 0 : 1;
+            }
+            if (o2 == null || o2.getId() == null) {
+                return -1;
+            }
+            return o1.getId().compareTo(o2.getId());
+        }
+    }
+
+    static class ByVersion implements Comparator<Driver> {
+
+        @Override
+        public int compare(Driver o1, Driver o2) {
+            if (o1 == null || o1.getVersion() == null) {
+                return o2 == null || o2.getVersion() == null ? 0 : 1;
+            }
+            if (o2 == null || o2.getVersion() == null) {
+                return -1;
+            }
+            return o1.getComparableVersion().compareTo(o2.getComparableVersion());
+        }
+    }
+}

--- a/src/main/java/com/github/webdriverextensions/DriverDownloader.java
+++ b/src/main/java/com/github/webdriverextensions/DriverDownloader.java
@@ -90,7 +90,7 @@ public class DriverDownloader {
         }
     }
 
-    private HttpClientBuilder prepareHttpClientBuilderWithTimeoutsAndProxySettings(Proxy proxySettings) throws MojoExecutionException {
+    private HttpClientBuilder prepareHttpClientBuilderWithTimeoutsAndProxySettings(Proxy proxySettings) {
         SocketConfig socketConfig = SocketConfig.custom().setSoTimeout(FILE_DOWNLOAD_READ_TIMEOUT).build();
         RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(FILE_DOWNLOAD_CONNECT_TIMEOUT)
                 .setCookieSpec(CookieSpecs.IGNORE_COOKIES).build();

--- a/src/main/java/com/github/webdriverextensions/DriverExtractor.java
+++ b/src/main/java/com/github/webdriverextensions/DriverExtractor.java
@@ -20,12 +20,12 @@ class DriverExtractor {
         FileExtractor fileExtractor = new FileExtractorImpl(driver.getFileMatchInside());
 
         try {
+            Files.createDirectories(mojo.tempDirectory);
             if (fileExtractor.isExtractable(downloadedFile)) {
                 mojo.getLog().info("  Extracting " + quote(downloadedFile) + " to temp folder");
                 fileExtractor.extractFile(downloadedFile, mojo.tempDirectory);
             } else {
                 mojo.getLog().info("  Copying " + quote(downloadedFile) + " to temp folder");
-                Files.createDirectories(mojo.tempDirectory);
                 Files.copy(downloadedFile, mojo.tempDirectory.resolve(downloadedFile.getFileName()));
             }
             if (!mojo.keepDownloadedWebdrivers) {

--- a/src/main/java/com/github/webdriverextensions/DriverVersionHandler.java
+++ b/src/main/java/com/github/webdriverextensions/DriverVersionHandler.java
@@ -3,6 +3,7 @@ package com.github.webdriverextensions;
 import org.apache.maven.plugin.MojoExecutionException;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 
 class DriverVersionHandler {
@@ -17,7 +18,7 @@ class DriverVersionHandler {
         String versionString = createVersionString(driver);
 
         try {
-            org.apache.commons.io.FileUtils.writeStringToFile(file.toFile(), versionString);
+            org.apache.commons.io.FileUtils.writeStringToFile(file.toFile(), versionString, Charset.defaultCharset());
         } catch (IOException e) {
             throw new RuntimeException("Failed to create version file containing metadata about the installed driver" + Utils.debugInfo(driver), e);
         }
@@ -37,7 +38,7 @@ class DriverVersionHandler {
             if (!versionFile.toFile().exists()) {
                 return false;
             }
-            String savedVersion = org.apache.commons.io.FileUtils.readFileToString(versionFile.toFile());
+            String savedVersion = org.apache.commons.io.FileUtils.readFileToString(versionFile.toFile(), Charset.defaultCharset());
             String currentVersion = createVersionString(driver);
             return savedVersion.equals(currentVersion);
         } catch (IOException e) {

--- a/src/main/java/com/github/webdriverextensions/InstallDriversMojo.java
+++ b/src/main/java/com/github/webdriverextensions/InstallDriversMojo.java
@@ -3,7 +3,6 @@ package com.github.webdriverextensions;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -15,7 +14,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,7 +23,7 @@ import static com.github.webdriverextensions.Utils.quote;
 @Mojo(name = "install-drivers", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class InstallDriversMojo extends AbstractMojo {
 
-    @Component
+    @Parameter(defaultValue = "${project}", readonly = true)
     MavenProject project;
 
     @Parameter(defaultValue = "${settings}", readonly = true)

--- a/src/main/java/com/github/webdriverextensions/ProxyUtils.java
+++ b/src/main/java/com/github/webdriverextensions/ProxyUtils.java
@@ -12,14 +12,14 @@ import java.net.Authenticator;
 import java.net.PasswordAuthentication;
 
 public class ProxyUtils {
-    public static HttpHost createProxyFromSettings(Proxy proxySettings) throws MojoExecutionException {
+    public static HttpHost createProxyFromSettings(Proxy proxySettings) {
         if (proxySettings == null) {
             return null;
         }
         return new HttpHost(proxySettings.getHost(), proxySettings.getPort());
     }
 
-    static CredentialsProvider createProxyCredentialsFromSettings(Proxy proxySettings) throws MojoExecutionException {
+    static CredentialsProvider createProxyCredentialsFromSettings(Proxy proxySettings) {
         if (proxySettings.getUsername() == null) {
             return null;
         }

--- a/src/main/java/com/github/webdriverextensions/Utils.java
+++ b/src/main/java/com/github/webdriverextensions/Utils.java
@@ -73,7 +73,7 @@ public class Utils {
                     return false;
             }
         }
-        return com.sun.jna.Platform.is64Bit();
+        return "64".equalsIgnoreCase(System.getProperty("sun.arch.data.model"));
     }
 
     public static String debugInfo(InstallDriversMojo mojo) {

--- a/src/test/java/com/github/webdriverextensions/AbstractInstallDriversMojoTest.java
+++ b/src/test/java/com/github/webdriverextensions/AbstractInstallDriversMojoTest.java
@@ -15,6 +15,7 @@ import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingRequest;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.junit.Assert;
 
 public abstract class AbstractInstallDriversMojoTest extends AbstractMojoTestCase {
@@ -33,6 +34,7 @@ public abstract class AbstractInstallDriversMojoTest extends AbstractMojoTestCas
         MavenExecutionRequest request = new DefaultMavenExecutionRequest();
         request.setPom(pom);
         ProjectBuildingRequest configuration = request.getProjectBuildingRequest();
+        configuration.setRepositorySession(new DefaultRepositorySystemSession());
         return lookup(ProjectBuilder.class).build(pom, configuration).getProject();
     }
 

--- a/src/test/java/com/github/webdriverextensions/AbstractInstallDriversMojoTest.java
+++ b/src/test/java/com/github/webdriverextensions/AbstractInstallDriversMojoTest.java
@@ -4,6 +4,7 @@ import static com.github.webdriverextensions.Utils.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
@@ -130,7 +131,7 @@ public abstract class AbstractInstallDriversMojoTest extends AbstractMojoTestCas
                 foundDriverVersionFile = true;
                 if (version != null) {
                     try {
-                        String versionFileString = FileUtils.readFileToString(file);
+                        String versionFileString = FileUtils.readFileToString(file, Charset.defaultCharset());
                         if (!versionFileString.contains("\"version\": \"" + version + "\"")) {
                             fail("Version " + version + " was not found in version file, version file content: " + versionFileString);
                         }

--- a/src/test/java/com/github/webdriverextensions/ComparableVersionTest.java
+++ b/src/test/java/com/github/webdriverextensions/ComparableVersionTest.java
@@ -2,8 +2,8 @@ package com.github.webdriverextensions;
 
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 public class ComparableVersionTest {
 

--- a/src/test/java/com/github/webdriverextensions/RepositoryTest.java
+++ b/src/test/java/com/github/webdriverextensions/RepositoryTest.java
@@ -1,20 +1,35 @@
 package com.github.webdriverextensions;
 
-import org.apache.maven.plugin.MojoExecutionException;
-import org.junit.Test;
-
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.localserver.LocalServerTestBase;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpRequestHandler;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
+import static org.junit.Assert.assertThrows;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 
-public class RepositoryTest {
+public class RepositoryTest extends LocalServerTestBase {
+    private HttpHost host;
 
     @Test
-    //@Ignore // Ignore this test if you use a proxy since it will fail
-    public void testConstructor() throws MojoExecutionException, InterruptedException, MalformedURLException {
-        URL repositoryFile = new URL("file://" + getClass().getResource("/repository-3.0.json").getPath());
+    public void testConstructor() throws MojoExecutionException, MalformedURLException {
+        URL repositoryFile = new URL(String.format("http://%s:%d/repository-3.0.json", host.getHostName(), host.getPort()));
         Driver driver = Repository.load(repositoryFile, null).getDrivers("chromedriver", "linux", "32", "2.9").get(0);
 
         assertThat(driver.getName(), is("chromedriver"));
@@ -23,4 +38,45 @@ public class RepositoryTest {
         assertThat(driver.getComparableVersion(), is(new ComparableVersion("2.9")));
         assertThat(driver.getUrl(), is("http://chromedriver.storage.googleapis.com/2.9/chromedriver_linux32.zip"));
     }
+
+    @Test
+    public void testLoadWithInvalidUrl() {
+        InstallDriversMojoExecutionException e = assertThrows(InstallDriversMojoExecutionException.class, new ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                // hostname missing
+                Repository.load(new URL("ftp:///"), null);
+            }
+        });
+        assertThat(e.getMessage(), startsWith("Failed to download repository from url"));
+        assertThat(e.getCause(), instanceOf(IOException.class));
+    }
+
+    @Test
+    public void testLoadWithFileNotFound() {
+        InstallDriversMojoExecutionException e = assertThrows(InstallDriversMojoExecutionException.class, new ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                Repository.load(new URL(String.format("http://%s:%d/404", host.getHostName(), host.getPort())), null);
+            }
+        });
+        assertThat(e.getMessage(), startsWith("Failed to parse repository json"));
+        assertThat(e.getCause(), instanceOf(NullPointerException.class));
+        assertThat(e.getCause().getMessage(), is("repository json is empty"));
+    }
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        serverBootstrap.registerHandler("/repository-3.0.json", new HttpRequestHandler() {
+            @Override
+            public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
+                response.setStatusCode(HttpStatus.SC_OK);
+                response.setEntity(new InputStreamEntity(getClass().getResource("/repository-3.0.json").openStream(), ContentType.APPLICATION_JSON));
+            }
+        });
+        host = start();
+    }
+    
 }

--- a/src/test/java/com/github/webdriverextensions/RepositoryTest.java
+++ b/src/test/java/com/github/webdriverextensions/RepositoryTest.java
@@ -6,8 +6,8 @@ import org.junit.Test;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 public class RepositoryTest {
 

--- a/src/test/java/com/github/webdriverextensions/newversion/FileExtractorImplTest.java
+++ b/src/test/java/com/github/webdriverextensions/newversion/FileExtractorImplTest.java
@@ -10,7 +10,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.Is.is;
 
 public class FileExtractorImplTest {
 


### PR DESCRIPTION
This makes the plugin compatible with Java 17 by removing lambdaj and its old cglib dependency. The plugin also regains compatibility with Java 1.7 after losing it due to dependency updates that required Java 1.8.

It also fixes two other bugs I discovered during unit testing:
1. the download directory was not always created
2. failed to move non-empty directories of downloaded drivers on Windows

fixes #56