### PR TITLE
Bump Java Source Level to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,19 +89,12 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Dependency Versions -->
-        <maven-core.version>3.3.9</maven-core.version><!-- 1st official maven release that requires Java 1.7 -->
-        <maven-plugin-annotations.version>3.3</maven-plugin-annotations.version>
+        <maven-core.version>3.6.3</maven-core.version>
+        <maven-plugin-annotations.version>3.6.1</maven-plugin-annotations.version>
         <maven-plugin-testing-harness.version>3.3.0</maven-plugin-testing-harness.version>
 
-        <commons-codec.version>1.15</commons-codec.version>
-        <commons-collections.version>4.2</commons-collections.version>
-        <commons-exec.version>1.3</commons-exec.version>
-        <commons-io.version>2.6</commons-io.version><!-- latest for java 1.7 -->
-        <commons-lang3.version>3.8.1</commons-lang3.version><!-- latest for java 1.7 -->
-        <gson.version>2.8.8</gson.version>
         <httpclient.version>4.5.13</httpclient.version>
         <junit.version>4.13.2</junit.version>
-        <selenium.version>2.53.1</selenium.version><!-- latest for java 1.7 -->
 
         <!-- Plugin Versions -->
         <github-site-maven-plugin.version>0.12</github-site-maven-plugin.version>
@@ -134,11 +127,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-exec</artifactId>
-            <version>${commons-exec.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
             <version>${maven-plugin-testing-harness.version}</version>
@@ -163,27 +151,22 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>${gson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-            <version>${commons-collections.version}</version>
+            <version>2.8.9</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>${commons-codec.version}</version>
+            <version>1.15</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -200,7 +183,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-api</artifactId>
-            <version>${selenium.version}</version>
+            <version>4.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -211,18 +194,18 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.20</version><!-- latest for java 1.7 -->
+            <version>1.21</version>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>2.2.0</version>
+            <version>3.21.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.28.2</version><!-- latest for java 1.7 -->
+            <version>4.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -233,8 +216,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <compilerArgs>

--- a/src/main/java/com/github/webdriverextensions/ComparableVersion.java
+++ b/src/main/java/com/github/webdriverextensions/ComparableVersion.java
@@ -95,16 +95,19 @@ public class ComparableVersion
             this.value = new BigInteger( str );
         }
 
+        @Override
         public int getType()
         {
             return INTEGER_ITEM;
         }
 
+        @Override
         public boolean isNull()
         {
             return BIG_INTEGER_ZERO.equals( value );
         }
 
+        @Override
         public int compareTo( Item item )
         {
             if ( item == null )
@@ -128,6 +131,7 @@ public class ComparableVersion
             }
         }
 
+        @Override
         public String toString()
         {
             return value.toString();
@@ -158,7 +162,7 @@ public class ComparableVersion
          */
         private static final String RELEASE_VERSION_INDEX = String.valueOf( _QUALIFIERS.indexOf( "" ) );
 
-        private String value;
+        private final String value;
 
         public StringItem( String value, boolean followedByDigit )
         {
@@ -181,11 +185,13 @@ public class ComparableVersion
             this.value = ALIASES.getProperty( value , value );
         }
 
+        @Override
         public int getType()
         {
             return STRING_ITEM;
         }
 
+        @Override
         public boolean isNull()
         {
             return ( comparableQualifier( value ).compareTo( RELEASE_VERSION_INDEX ) == 0 );
@@ -210,6 +216,7 @@ public class ComparableVersion
             return i == -1 ? ( _QUALIFIERS.size() + "-" + qualifier ) : String.valueOf( i );
         }
 
+        @Override
         public int compareTo( Item item )
         {
             if ( item == null )
@@ -233,6 +240,7 @@ public class ComparableVersion
             }
         }
 
+        @Override
         public String toString()
         {
             return value;
@@ -247,14 +255,16 @@ public class ComparableVersion
         extends ArrayList<Item>
         implements Item
     {
+        @Override
         public int getType()
         {
             return LIST_ITEM;
         }
 
+        @Override
         public boolean isNull()
         {
-            return ( size() == 0 );
+            return isEmpty();
         }
 
         void normalize()
@@ -273,11 +283,12 @@ public class ComparableVersion
             }
         }
 
+        @Override
         public int compareTo( Item item )
         {
             if ( item == null )
             {
-                if ( size() == 0 )
+                if ( isEmpty() )
                 {
                     return 0; // 1-0 = 1- (normalize) = 1
                 }
@@ -317,6 +328,7 @@ public class ComparableVersion
             }
         }
 
+        @Override
         public String toString()
         {
             StringBuilder buffer = new StringBuilder( "(" );
@@ -348,7 +360,7 @@ public class ComparableVersion
 
         ListItem list = items;
 
-        Stack<Item> stack = new Stack<Item>();
+        Stack<Item> stack = new Stack<>();
         stack.push( list );
 
         boolean isDigit = false;
@@ -438,21 +450,25 @@ public class ComparableVersion
         return isDigit ? new IntegerItem( buf ) : new StringItem( buf, false );
     }
 
+    @Override
     public int compareTo( ComparableVersion o )
     {
         return items.compareTo( o.items );
     }
 
+    @Override
     public String toString()
     {
         return value;
     }
 
+    @Override
     public boolean equals( Object o )
     {
         return ( o instanceof ComparableVersion ) && canonical.equals( ( (ComparableVersion) o ).canonical );
     }
 
+    @Override
     public int hashCode()
     {
         return canonical.hashCode();

--- a/src/main/java/com/github/webdriverextensions/Driver.java
+++ b/src/main/java/com/github/webdriverextensions/Driver.java
@@ -1,18 +1,26 @@
 package com.github.webdriverextensions;
 
 import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.Expose;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
 public class Driver {
 
+    @Expose
     private String name;
+    @Expose
     private String platform;
+    @Expose
     private String bit;
+    @Expose
     private String version;
+    @Expose
     private String url;
+    @Expose
     private String fileMatchInside;
+    @Expose
     private String customFileName;
 
     public String getId() {

--- a/src/main/java/com/github/webdriverextensions/InstallDriversMojo.java
+++ b/src/main/java/com/github/webdriverextensions/InstallDriversMojo.java
@@ -152,6 +152,7 @@ public class InstallDriversMojo extends AbstractMojo {
         }
     }
 
+    @Override
     public void execute() throws MojoExecutionException {
 
         if (settings.isOffline()) {

--- a/src/main/java/com/github/webdriverextensions/ProxyUtils.java
+++ b/src/main/java/com/github/webdriverextensions/ProxyUtils.java
@@ -8,11 +8,12 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.settings.Proxy;
 
-import java.net.Authenticator;
-import java.net.PasswordAuthentication;
+class ProxyUtils {
 
-public class ProxyUtils {
-    public static HttpHost createProxyFromSettings(Proxy proxySettings) {
+    private ProxyUtils() {
+    }
+    
+    static HttpHost createProxyFromSettings(Proxy proxySettings) {
         if (proxySettings == null) {
             return null;
         }
@@ -30,18 +31,7 @@ public class ProxyUtils {
         return credentialsProvider;
     }
 
-    public static void setProxyAuthenticator(final Proxy proxy) {
-        Authenticator authenticator = new Authenticator() {
-            @Override
-            public PasswordAuthentication getPasswordAuthentication() {
-                return (new PasswordAuthentication(proxy.getUsername(),
-                        proxy.getPassword().toCharArray()));
-            }
-        };
-        Authenticator.setDefault(authenticator);
-    }
-
-    public static Proxy getProxyFromSettings(InstallDriversMojo mojo) throws MojoExecutionException {
+    static Proxy getProxyFromSettings(InstallDriversMojo mojo) throws MojoExecutionException {
         if (mojo.settings == null) {
             return null;
         }

--- a/src/main/java/com/github/webdriverextensions/Utils.java
+++ b/src/main/java/com/github/webdriverextensions/Utils.java
@@ -110,7 +110,7 @@ public class Utils {
                 DirectoryFileFilter.DIRECTORY
         );
 
-        if (files.size() == 0) {
+        if (files.isEmpty()) {
             return path + " is empty" + System.lineSeparator();
         }
 


### PR DESCRIPTION
- previous version already had an implicit requirement to java 1.8
- allows usage of modern APIs
- allows usage of current versions of 3rd party libs
- removes the requirement of some 3rd party libs
