### PR TITLE
fix keepDownloadedWebdrivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ path through the configuration parameter named `installationDirectory`.
 
 ### Keeping downloaded data in the cache
 To avoid downloading the drivers more than once if you switch between 
-driver versions or something similar you could set `<keepDownloadedWebdrivers>true</keepDownloadedWebdrivers>` configuration paramter.
+driver versions or something similar you could set `<keepDownloadedWebdrivers>true</keepDownloadedWebdrivers>` configuration paramter. Please note that you must also provide a fixed path for `pluginWorkingDirectory` otherwise `keepDownloadedWebdrivers=true` will be ignored!
 ```xml
 <plugin>
     <groupId>com.github.webdriverextensions</groupId>
@@ -279,6 +279,7 @@ driver versions or something similar you could set `<keepDownloadedWebdrivers>tr
     </executions>
     <configuration>
         <keepDownloadedWebdrivers>true</keepDownloadedWebdrivers>
+        <pluginWorkingDirectory>/some/directory</pluginWorkingDirectory>
         <drivers>
             ... drivers to install
         </drivers>
@@ -366,6 +367,7 @@ For more details on how to further configure this plugin please see the
 ## Changelog
 
 #### Unreleased
+- BUGFIX `keepDownloadedWebdrivers` did not work as expected
 - IMPROVEMENT configure download timeouts and retry attempts
 - IMPROVEMENT Added support for Java 17 [Issue 56](https://github.com/webdriverextensions/webdriverextensions-maven-plugin/issues/56)
 - BUGFIX failed to move non-empty directories of downloaded drivers on Windows [Issue 56](https://github.com/webdriverextensions/webdriverextensions-maven-plugin/issues/56)

--- a/src/main/java/com/github/webdriverextensions/Utils.java
+++ b/src/main/java/com/github/webdriverextensions/Utils.java
@@ -88,6 +88,9 @@ public class Utils {
     }
 
     public static String directoryToString(Path path) {
+        if (path == null) {
+            return "null";
+        }
         if (!path.toFile().exists()) {
             return path + " does not exist" + System.lineSeparator();
         }

--- a/src/test/java/com/github/webdriverextensions/AbstractInstallDriversMojoTest.java
+++ b/src/test/java/com/github/webdriverextensions/AbstractInstallDriversMojoTest.java
@@ -68,7 +68,7 @@ public abstract class AbstractInstallDriversMojoTest extends AbstractMojoTestCas
         logTestName(mojo);
 
         mojo.repositoryUrl = Thread.currentThread().getContextClassLoader().getResource("repository-3.0.json");
-        mojo.installationDirectory = tempFolder.getRoot();
+        mojo.installationDirectory = tempFolder.newFolder();
         DriverDownloader dlMock = Mockito.mock(DriverDownloader.class);
         when(dlMock.downloadFile(any(Driver.class), any(Path.class))).thenAnswer(new DownloadAnswer());
         doReturn(dlMock).when(mojo).getDownloader();

--- a/src/test/java/com/github/webdriverextensions/InstallDriversMojoTest.java
+++ b/src/test/java/com/github/webdriverextensions/InstallDriversMojoTest.java
@@ -129,6 +129,36 @@ public class InstallDriversMojoTest extends AbstractInstallDriversMojoTest {
         assertNumberOfInstalledDriverIs(1);
     }
 
+    public void test_that_configuration_with_keepDownloadedWebdrivers_keeps_workdingDirectory() throws Exception {
+        // Given
+        InstallDriversMojo mojo = getMojo("src/test/resources/custom_driver_single_file_pom.xml");
+        mojo.keepDownloadedWebdrivers = true;
+        mojo.pluginWorkingDirectory = tempFolder.newFolder();
+
+        // When
+        mojo.execute();
+
+        // Then
+        assertDriverIsInstalled("custom-chrome-driver-windows-32bit.exe");
+        assertNumberOfInstalledDriverIs(1);
+        assertThat(mojo.pluginWorkingDirectory).isDirectory();
+    }
+
+    public void test_that_configuration_without_keepDownloadedWebdrivers_deletes_workdingDirectory() throws Exception {
+        // Given
+        InstallDriversMojo mojo = getMojo("src/test/resources/custom_driver_single_file_pom.xml");
+        mojo.keepDownloadedWebdrivers = false;
+        mojo.pluginWorkingDirectory = tempFolder.newFolder();
+
+        // When
+        mojo.execute();
+
+        // Then
+        assertDriverIsInstalled("custom-chrome-driver-windows-32bit.exe");
+        assertNumberOfInstalledDriverIs(1);
+        assertThat(mojo.pluginWorkingDirectory).doesNotExist();
+    }
+
     public void test_that_configuration_with_custom_driver_containing_directory_not_in_repository_works() throws Exception {
         // Given
         InstallDriversMojo mojo = getMojo("src/test/resources/custom_driver_directory_pom.xml");


### PR DESCRIPTION
`keepDownloadedWebdrivers=true` did not work as expected because the working directory was a **random** temporary folder.
it is now possible to define a fixed working directory via `pluginWorkingDirectory` which is a requirement for `keepDownloadedWebdrivers=true` to work as expected.